### PR TITLE
Fix inaccurate typespecs

### DIFF
--- a/lib/glicko/player.ex
+++ b/lib/glicko/player.ex
@@ -143,7 +143,7 @@ defmodule Glicko.Player do
   @doc """
   A version agnostic method for getting a player's rating.
   """
-  @spec rating(player :: t, as_version :: version) :: rating
+  @spec rating(player :: t, as_version :: version | nil) :: rating
   def rating(player, as_version \\ nil)
   def rating({rating, _}, nil), do: rating
   def rating({rating, _, _}, nil), do: rating
@@ -155,7 +155,7 @@ defmodule Glicko.Player do
   @doc """
   A version agnostic method for getting a player's rating deviation.
   """
-  @spec rating_deviation(player :: t, as_version :: version) :: rating_deviation
+  @spec rating_deviation(player :: t, as_version :: version | nil) :: rating_deviation
   def rating_deviation(player, as_version \\ nil)
   def rating_deviation({_, rating_deviation}, nil), do: rating_deviation
   def rating_deviation({_, rating_deviation, _}, nil), do: rating_deviation
@@ -192,7 +192,7 @@ defmodule Glicko.Player do
   When a player has a low RD, the interval would be narrow, so that we would
   be 95% confident about a player’s strength being in a small interval of values.
   """
-  @spec rating_interval(player :: t) :: {rating_low :: float, rating_high :: float}
+  @spec rating_interval(player :: t, as_version :: version | nil) :: {rating_low :: float, rating_high :: float}
   def rating_interval(player, as_version \\ nil) do
     {
       rating(player, as_version) - rating_deviation(player, as_version) * 2,

--- a/lib/glicko/result.ex
+++ b/lib/glicko/result.ex
@@ -52,18 +52,18 @@ defmodule Glicko.Result do
   @doc """
   Convenience function for accessing an opponent's rating.
   """
-  @spec opponent_rating(result :: Result.t()) :: Player.rating()
+  @spec opponent_rating(result :: t()) :: Player.rating()
   def opponent_rating(_result = {rating, _, _}), do: rating
 
   @doc """
   Convenience function for accessing an opponent's rating deviation.
   """
-  @spec opponent_rating_deviation(result :: Result.t()) :: Player.rating_deviation()
+  @spec opponent_rating_deviation(result :: t()) :: Player.rating_deviation()
   def opponent_rating_deviation(_result = {_, rating_deviation, _}), do: rating_deviation
 
   @doc """
   Convenience function for accessing the score.
   """
-  @spec score(result :: Result.t()) :: score
+  @spec score(result :: t()) :: score
   def score(_result = {_, _, score}), do: score
 end


### PR DESCRIPTION
1. `rating`, `rating_deviation`, and `rating_interval` all omit the possibility of receiving a `nil` as the second argument.
2. Writing out `Result.t()`  results in `dialyzer` looking for `Elixir.Result.t()`, instead of calling the local `Elixir.Glicko.Result.t()`.