### PR TITLE
Update algorithm to match the latest Glicko-2 documentation

### DIFF
--- a/lib/glicko.ex
+++ b/lib/glicko.ex
@@ -268,7 +268,7 @@ defmodule Glicko do
       fc = calc_f(alpha, delta, player_pre_rd_sq, variance_est, sys_const, c)
 
       {a, fa} =
-        if fc * fb < 0 do
+        if fc * fb <= 0 do
           {b, fb}
         else
           {a, fa / 2}


### PR DESCRIPTION
On 2022-03-22, the Glicko-2 algorithm was updated, with the following line being added to the [Glicko web page][1]:

> This document has been revised on March 22, 2022, to replace a "<" with "<=" in item 4(b) of Step 5 (page 3).

See the [Glicko-2 document][2] for details.

Tests for this change are missing, as at the time of writing I couldn't figure out a test that only made use of the current public interface. I took [one of the existing tests][3] and turned it into a property based test (generating [the ratings, rating deviations, etc.][4]), where I tried to see if some of the randomly generated inputs would result in the new algorithm returning a different result from `Glicko.new_rating/3` (I added slight change to the code that allowed for selecting between the algorithms), but all the randomly generated input yielded no different result. Without putting in a lot of research, I can't figure out what a good test should look like.

  [1]: http://glicko.net/glicko.html
  [2]: http://glicko.net/glicko/glicko2.pdf
  [3]: https://github.com/avitex/elixir-glicko/blob/b7b60afbe33d3f2402b3aa0f7bd1fa653f404bee/test/glicko_test.exs#L27-L37
  [4]: https://github.com/avitex/elixir-glicko/blob/b7b60afbe33d3f2402b3aa0f7bd1fa653f404bee/test/glicko_test.exs#L11-L17